### PR TITLE
Added typescript as a dev dependency

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,5 +11,8 @@
   "dependencies": {
     "convex": "^1.13.0",
     "openai": "^4.45.0"
+  },
+   "devDependencies": {
+    "typescript": "^5.7.3"
   }
 }


### PR DESCRIPTION
Added typescript as a dev dependency. This fixes type-checking from failing during `convex dev`, due to tsc not being found.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
