### PR TITLE
Fix: Added try/catch error handling to delete action button

### DIFF
--- a/apps/web/src/components/notes/DeleteNote.tsx
+++ b/apps/web/src/components/notes/DeleteNote.tsx
@@ -81,8 +81,12 @@ export default function DeleteNote({ deleteAction }: any) {
                       type="button"
                       className="inline-flex w-full justify-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-red-500 sm:ml-3 sm:w-auto"
                       onClick={() => {
+                        try{
                         deleteAction();
                         setOpen(false);
+                        } catch{
+                           console.error("Error deleting note, something went wrong:", error);
+                        }
                       }}
                     >
                       Delete


### PR DESCRIPTION
The delete note fucntionality was missing error handling on client side. So I wrapped the delete action function inside a try/catch block for better error handling.
<!-- Describe your PR here. -->


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
